### PR TITLE
Add support for secrets management

### DIFF
--- a/gordon/core.py
+++ b/gordon/core.py
@@ -448,6 +448,7 @@ class ProjectApply(ProjectApplyLoopBase):
         parameters_paths = (
             os.path.join(self.path, 'parameters', 'common.yml'),
             os.path.join(self.path, 'parameters', '{}.yml'.format(self.stage)),
+            os.path.join(self.path, 'parameters', '{}_secrets.yml'.format(self.stage)),
         )
 
         # Retrieve the account_id of the credentials currently in use.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ install_requires = [
     'PyYAML>=3,<4.0',
     'troposphere>=1.6,<2.0',
     'Jinja2>=2.8,<3.0',
-    'six>1.9,<2.0'
+    'six>1.9,<2.0',
+    'ansible_vault>=1.0.4,<2.0'
 ]
 
 # as of Python >= 2.7 argparse module is maintained within Python.
@@ -18,7 +19,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name='gordon',
-    version='0.2.1',
+    version='0.2.1.1',
     url='http://github.com/jorgebastida/gordon',
     license='BSD',
     author='Jorge Bastida',


### PR DESCRIPTION
This PR adds support to secrets management to `gordon` by integrating `ansible-vault`. It loads any file called `{stage}_secrets.yml` in the parameters folders, decrypt it using the provided password through the environment variable `VAULT_PASSWORD_{stage}` and inject it in the gordon context so that it is transparent for the lambda code using it.

To deploy the project containing secrets: `VAULT_PASSWORD_{stage} gordon apply`
